### PR TITLE
LPS-139654 Ignore long-running integration test class

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/IsolationAcrossCompaniesTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/IsolationAcrossCompaniesTest.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +40,7 @@ import org.osgi.framework.BundleActivator;
 /**
  * @author Carlos Sierra Andrés
  */
+@Ignore
 @RunWith(Arquillian.class)
 public class IsolationAcrossCompaniesTest extends BaseClientTestCase {
 


### PR DESCRIPTION
[LPS-139654](https://issues.liferay.com/browse/LPS-139654)

Note: We ignore these tests until [LPS-138709](https://issues.liferay.com/browse/LPS-138709) is not fixed.

cc @stian-sigvartsen